### PR TITLE
Added trident-eval-print-last-expression.

### DIFF
--- a/trident-mode.el
+++ b/trident-mode.el
@@ -385,10 +385,7 @@ the current buffer."
 (defun trident-eval-buffer ()
   "Evaluate the current buffer as Parenscript."
   (interactive)
-  (prog1
-      (trident-eval-region (point-min) (point-max))
-    (when slime-highlight-edits-mode
-      (slime-remove-edits (point-min) (point-max)))))
+  (trident-eval-region (point-min) (point-max)))
 
 (defun trident-eval-dwim ()
   "Evaluate the active region or toplevel form.

--- a/trident-mode.el
+++ b/trident-mode.el
@@ -385,7 +385,10 @@ the current buffer."
 (defun trident-eval-buffer ()
   "Evaluate the current buffer as Parenscript."
   (interactive)
-  (trident-eval-region (point-min) (point-max)))
+  (prog1
+      (trident-eval-region (point-min) (point-max))
+    (when slime-highlight-edits-mode
+      (slime-remove-edits (point-min) (point-max)))))
 
 (defun trident-eval-dwim ()
   "Evaluate the active region or toplevel form.


### PR DESCRIPTION
I have added `trident-eval-print-last-expression` based on a combination of the equivalent Skewer and Slime functions. `trident-eval-last-expression` now accepts a prefix argument so that `C-u C-c t e e` (in my case) will invoke the new behaviour (by analogy with `C-u C-x C-e`).

I haven't made many pull requests so please let me know if I'm doing it wrong (e.g. this description needs more detail, justification etc.). Cheers!